### PR TITLE
feat(skills): add deeplabcut + markdown-report-writing; sync README to 50 skills / 16 categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Cognitive and Neuroscience Skills
 
-![Skills](https://img.shields.io/badge/skills-46-blue)
+![Skills](https://img.shields.io/badge/skills-50-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Platform](https://img.shields.io/badge/platform-Claude%20Code-blueviolet)
 ![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen)
@@ -28,7 +28,7 @@ Install directly in Claude Code:
 
 Then `restart` Claude Code to activate the skills.
 
-All 47 skills become immediately available. Skills activate automatically when you ask research methodology questions:
+All 50 skills become immediately available. Skills activate automatically when you ask research methodology questions:
 
 - "Help me design an oddball paradigm for N400 research"
 - "What preprocessing pipeline should I use for my fMRI data?"
@@ -64,7 +64,7 @@ Skills are classified primarily by **research content domain** — the scientifi
 
 ## Skills Catalog
 
-> **46 skills** across 13 categories
+> **50 skills** across 16 categories
 
 ### Meta-Skills (7)
 
@@ -117,7 +117,7 @@ Skills are classified primarily by **research content domain** — the scientifi
 | [`eeg-preprocessing-pipeline-guide`](skills/eeg-preprocessing-pipeline-guide/) | Filtering, ICA/ASR, re-referencing, interpolation, QC |
 | [`mne-python-guide`](skills/mne-python-guide/) | MNE-Python pipeline: loading, preprocessing, epoching, ERP/ERF, time-frequency, source localization, decoding |
 
-### fMRI / Neuroimaging (7)
+### fMRI / Neuroimaging (8)
 
 | Skill | Description |
 |---|---|
@@ -154,6 +154,12 @@ Skills are classified primarily by **research content domain** — the scientifi
 | [`calcium-imaging-analysis-guide`](skills/calcium-imaging-analysis-guide/) | Motion correction, ROI extraction, neuropil correction, spike inference |
 | [`optogenetics-protocol-designer`](skills/optogenetics-protocol-designer/) | Opsin choice, light delivery, pulse protocols, fiber placement |
 
+### Electrophysiology (1)
+
+| Skill | Description |
+|---|---|
+| [`spikeinterface-skill`](skills/spikeinterface-skill/) | Extracellular electrophysiology pipeline with SpikeInterface: extractors for ~40 acquisition formats, preprocessing, spike sorters (Kilosort family, Mountainsort, SpykingCircus, Tridesclous, Lupin, HerdingSpikes) via native or Docker/Singularity runs, `SortingAnalyzer` post-processing, quality metrics, curation, comparison, plot_* widgets, export to Phy/IBL/Pynapple |
+
 ### Clinical / Neuropsychology (2)
 
 | Skill | Description |
@@ -172,6 +178,18 @@ Skills are classified primarily by **research content domain** — the scientifi
 | Skill | Description |
 |---|---|
 | [`tom-task-selector`](skills/tom-task-selector/) | ToM task selection by population, age, and construct |
+
+### Animal Behavior (1)
+
+| Skill | Description |
+|---|---|
+| [`deeplabcut`](skills/deeplabcut/) | Markerless animal pose estimation with DeepLabCut: single/multi-animal tracking, SuperAnimal pretrained models, 2D/3D pose, keypoint labeling GUI, model training/evaluation, video analysis |
+
+### Writing (1)
+
+| Skill | Description |
+|---|---|
+| [`markdown-report-writing`](skills/markdown-report-writing/) | Guide for well-structured, visually polished Markdown reports across GitHub and Obsidian: three-layer writing model, Mermaid diagrams, math, tables, callouts, cross-renderer compatibility |
 
 ### Others (2)
 

--- a/skills/deeplabcut/SKILL.md
+++ b/skills/deeplabcut/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: deeplabcut
+description: "Toolbox for markerless animal pose estimation with DeepLabCut. Covers single/multi-animal tracking, SuperAnimal pretrained models, 2D/3D pose estimation, keypoint labeling GUI, model training/evaluation, video analysis, and behavioral quantification. Use when the user needs animal pose estimation, behavior tracking, keypoint detection in videos, or mentions DeepLabCut/DLC/SuperAnimal."
+version: "1.0.0"
+authors:
+  - "Claude (AI-assisted)"
+review_status: "ai-generated"
+source: "https://github.com/DeepLabCut/DeepLabCut"
+---
+
+# DeepLabCut — Markerless Animal Pose Estimation
+
+## Purpose
+
+DeepLabCut is a Python toolbox for state-of-the-art markerless pose estimation of animals. It uses deep learning to track body parts from videos without physical markers. The library is animal-agnostic, supports both single and multi-animal scenarios, and includes the SuperAnimal family of pretrained models for out-of-the-box inference.
+
+## When to Use This Skill
+
+Activate when the user:
+- Wants to track animal body parts from video
+- Asks about pose estimation, keypoint detection, or behavioral tracking
+- Mentions DeepLabCut, DLC, SuperAnimal, or markerless tracking
+- Needs to analyze animal movement/kinematics
+- Asks about multi-animal tracking or 3D pose reconstruction
+- Wants to use pretrained animal pose models
+
+## Quick Decision Tree
+
+```
+What does the user need?
+├── No labeled data, just want to track animals → SuperAnimal (video_inference_superanimal)
+├── Single animal, have labeled data → Standard single-animal pipeline
+├── Multiple animals interacting → maDLC (multi-animal pipeline)
+├── 3D pose reconstruction → 3D pipeline (calibrate_cameras + triangulate)
+└── Just post-process results → filterpredictions, analyzeskeleton
+```
+
+## Reference Files (Progressive Disclosure)
+
+| Topic | File | When to Read |
+|-------|------|--------------|
+| Standard Pipeline | `references/standard-pipeline.md` | Full workflow: create project → train → analyze |
+| SuperAnimal & ModelZoo | `references/modelzoo.md` | Pretrained models, zero-shot inference |
+| Multi-Animal (maDLC) | `references/maDLC.md` | Tracking multiple interacting animals |
+| 3D Pose Estimation | `references/3d-pose.md` | Triangulation from multiple camera views |
+| Video & Data Utilities | `references/utilities.md` | Video cropping, format conversion, data export |
+
+## Installation
+
+```bash
+# Minimal (headless, no GUI):
+pip install deeplabcut
+
+# With GUI (label_frames, refine_labels, SkeletonBuilder):
+pip install "deeplabcut[gui]"
+
+# PyTorch must be installed separately:
+pip install torch torchvision
+# Or for GPU (check pytorch.org for your CUDA version):
+conda install pytorch cudatoolkit=11.3 -c pytorch
+```
+
+Verify: `python -c "import deeplabcut; print(deeplabcut.__version__)"`
+
+## Standard Pipeline Overview
+
+```python
+import deeplabcut as dlc
+
+# 1. Create project
+config_path = dlc.create_new_project(
+    "ProjectName", "ExperimenterName", ["/path/to/video.mp4"],
+    working_directory="/path/to/projects"
+)
+
+# 2. Extract frames for labeling
+dlc.extract_frames(config_path, mode="automatic", algo="kmeans", crop=True)
+
+# 3. USER labels frames manually in GUI
+# dlc.label_frames(config_path)  # launches the labeling GUI
+
+# 4. Create training dataset from labeled frames
+dlc.create_training_dataset(config_path, net_type="resnet_50")
+
+# 5. Train the network
+dlc.train_network(config_path, maxiters=100000, saveiters=5000)
+
+# 6. Evaluate
+dlc.evaluate_network(config_path, plotting=True)
+
+# 7. Analyze videos (predict poses)
+dlc.analyze_videos(config_path, ["/path/to/video.mp4"], videotype=".mp4")
+
+# 8. Create labeled videos (overlay predictions)
+dlc.create_labeled_video(config_path, ["/path/to/video.mp4"])
+
+# 9. Export results to CSV
+dlc.analyze_videos_converth5_to_csv("/path/to/videoDLC_resnet50_ProjectNameJul9")
+```
+
+## Key API Reference
+
+### Project Management
+
+| Function | Description |
+|----------|-------------|
+| `create_new_project(project, experimenter, videos, working_directory)` | Start a new single-animal project |
+| `create_new_project_3d(project, experimenter, num_cameras, working_directory)` | Start a new 3D project |
+| `create_pretrained_project(path, task, videos, SUPERANIMAL_NAME, model_name, detector_name)` | Create project from SuperAnimal pretrained model |
+| `add_new_videos(config_path, videos)` | Add videos to existing project |
+
+### Training & Evaluation
+
+| Function | Description |
+|----------|-------------|
+| `create_training_dataset(config_path, net_type, augmenter_type)` | Prepare training data; `net_type`: `resnet_50`, `resnet_101`, `mobilenet_v2_1.0`, `efficientnet-b0` |
+| `train_network(config_path, maxiters, saveiters)` | Train; key params: `maxiters=100000`, `saveiters=5000` |
+| `evaluate_network(config_path, plotting=True)` | Evaluate on test set, produce metrics |
+
+### Video Analysis
+
+| Function | Description |
+|----------|-------------|
+| `analyze_videos(config_path, videos, videotype, save_as_csv)` | Predict poses for all frames in videos |
+| `create_labeled_video(config_path, videos, videotype, filtered)` | Overlay predicted keypoints on video |
+| `video_inference_superanimal(videos, superanimal_name, ...)` | Zero-shot inference with pretrained SuperAnimal models |
+
+### Post-Processing
+
+| Function | Description |
+|----------|-------------|
+| `filterpredictions(config_path, video, ...)` | Smooth predictions (ARIMA, median filtering) |
+| `analyzeskeleton(config_path, video, ...)` | Compute bone lengths, joint angles from predictions |
+| `plot_trajectories(config_path, video, ...)` | Plot body part trajectories over time |
+
+### SuperAnimal Pretrained Models
+
+Available models for zero-shot inference:
+
+| Model | Species | Body Parts |
+|-------|---------|------------|
+| `superanimal_topviewmouse` | Top-view mouse (various strains) | 21 keypoints |
+| `superanimal_quadruped` | Quadrupeds (dog, horse, sheep, etc.) | 39 keypoints |
+| `superanimal_face` | Primate/human faces | 54 keypoints |
+| `superanimal_full` | Full body animals (topview mouse + quadruped) | Combined |
+
+## Common Pitfalls
+
+1. **Wrong PyTorch version**: Always install PyTorch BEFORE deeplabcut. Check [pytorch.org](https://pytorch.org) for the correct CUDA version.
+2. **GPU out of memory**: Reduce batch size (default 8 → 4 or 2) in `pose_cfg.yaml`.
+3. **Missing GUI dependencies**: `label_frames` requires `pip install "deeplabcut[gui]"`. On headless servers, use X11 forwarding or label locally.
+4. **Video codec issues**: If `create_labeled_video` fails, try converting to `.mp4` (H.264) or `.avi` first.
+5. **maDLC detector**: Multi-animal mode requires a detection model (`fasterrcnn_resnet50_fpn_v2` is the default). Single-animal can work with heatmap regression alone.
+6. **SuperAnimal scale**: Adjust `scale_list` parameter for SuperAnimal — try `[200, 300, 400]` first; smaller animals may need higher values.

--- a/skills/deeplabcut/references/3d-pose.md
+++ b/skills/deeplabcut/references/3d-pose.md
@@ -1,0 +1,89 @@
+# 3D Pose Estimation Reference
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Camera Setup & Calibration](#camera-setup-calibration)
+3. [3D Triangulation](#3d-triangulation)
+4. [Creating 3D Labeled Videos](#creating-3d-labeled-videos)
+
+## Overview
+
+DeepLabCut 3D reconstructs 3D poses from 2+ calibrated camera views. The workflow:
+
+```
+Multiple cameras → Calibrate → Analyze each view (2D) → Triangulate → 3D poses
+```
+
+## Camera Setup & Calibration
+
+```python
+import deeplabcut as dlc
+
+# Create 3D project
+config_path = dlc.create_new_project_3d(
+    "3D_Project",
+    "ExperimenterName",
+    num_cameras=2,               # number of camera views
+    working_directory="/path/to/projects",
+)
+```
+
+Calibration requires a checkerboard visible in all cameras simultaneously:
+
+```python
+# Calibrate cameras
+dlc.calibrate_cameras(
+    config_path,
+    cbrow=8,            # checkerboard rows (inner corners)
+    cbcol=6,            # checkerboard cols (inner corners)
+    calibrate=False,    # True to run calibration
+    alpha=0,            # 0 = crop to valid region; 1 = keep all pixels
+)
+
+# Verify calibration quality
+dlc.check_undistortion(
+    config_path,
+    cbrow=8,
+    cbcol=6,
+)
+```
+
+## 3D Triangulation
+
+Each camera view is analyzed independently, then triangulated:
+
+```python
+# Step 1: Analyze each camera's video separately
+for cam_config in camera_configs:
+    dlc.analyze_videos(cam_config, [f"camera{i}_video.mp4"])
+    dlc.filterpredictions(cam_config, [f"camera{i}_video.mp4"])
+
+# Step 2: Triangulate 2D→3D
+dlc.triangulate(
+    config_path,
+    video_path="/path/to/videos/",
+    filterpredictions=True,
+    videotype=".mp4",
+)
+```
+
+## Creating 3D Labeled Videos
+
+```python
+dlc.create_labeled_video_3d(
+    config_path,
+    path="/path/to/videos/",
+    start=0,            # start frame
+    end=1000,           # end frame
+    videotype=".mp4",
+)
+```
+
+## Calibration Tips
+
+- Use a printed checkerboard with known square size (in mm)
+- Film the checkerboard moving through all areas where the animal moves
+- Record at least 30-50 synchronized frames of the checkerboard from each camera
+- `pick_corners`: if `True`, manually click corners on one frame; `False` for automatic detection
+- Sync cameras with a flash/LED or use hardware triggers
+- Higher resolution cameras give better 3D accuracy

--- a/skills/deeplabcut/references/maDLC.md
+++ b/skills/deeplabcut/references/maDLC.md
@@ -1,0 +1,123 @@
+# Multi-Animal Pose Estimation (maDLC) Reference
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Creating a maDLC Project](#creating-a-madlc-project)
+3. [Training maDLC](#training-madlc)
+4. [Video Analysis for maDLC](#video-analysis-for-madlc)
+5. [Tracking & Tracklets](#tracking-tracklets)
+
+## Overview
+
+Multi-animal DeepLabCut supports tracking multiple interacting animals simultaneously. It uses a two-step approach:
+1. **Detection**: Find all animals in each frame (Faster R-CNN)
+2. **Pose estimation**: Estimate keypoints for each detected animal
+
+Then **tracking** links detections across frames to form persistent animal identities.
+
+## Creating a maDLC Project
+
+```python
+import deeplabcut as dlc
+
+config_path = dlc.create_new_project(
+    "MultiMouseProject",
+    "ExperimenterName",
+    ["/path/to/video.mp4"],
+    working_directory="/path/to/projects",
+    multianimal=True,        # KEY: enables maDLC mode
+)
+```
+
+In `config.yaml`, the `individuals` field lists the animals to track:
+
+```yaml
+individuals:
+- mouse1
+- mouse2
+- mouse3
+```
+
+The skeleton defines connections both within and optionally between animals.
+
+## Training maDLC
+
+maDLC uses two networks: a detector and a pose model.
+
+```python
+# Create training dataset (trains both detector + pose model)
+dlc.create_multianimaltraining_dataset(
+    config_path,
+    net_type="dlcrnet_ms5",      # good for multi-animal
+    detector_type="fasterrcnn_resnet50_fpn_v2",
+    num_shuffles=1,
+)
+
+# Train
+dlc.train_network(
+    config_path,
+    maxiters=100000,
+    saveiters=5000,
+)
+```
+
+**Key differences from single-animal:**
+- Labels include animal identity (which mouse is which)
+- Detector network runs first to find all animals
+- `numframes2pick` is per-animal; label ~20 frames per individual
+- Labeling is more time-consuming; use the GUI's animal switching feature
+
+## Video Analysis for maDLC
+
+```python
+# Analyze
+dlc.analyze_videos(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    auto_track=True,      # track animals across frames
+    track_method="box",   # "box" (IoU) or "skeleton" (pose similarity)
+)
+
+# Create labeled video
+dlc.create_labeled_video(
+    config_path,
+    ["/path/to/video.mp4"],
+    filtered=True,
+    videotype=".mp4",
+)
+```
+
+## Tracking & Tracklets
+
+After analysis, refine tracking:
+
+```python
+# Convert detections to tracklets
+dlc.convert_detections2tracklets(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    track_method="box",
+)
+
+# Manually refine tracklets in GUI
+# dlc.refine_tracklets(config_path, ["/path/to/video.mp4"])
+
+# Stitch corrected tracklets into final predictions
+dlc.stitch_tracklets(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+)
+```
+
+## Common Issues
+
+| Problem | Solution |
+|---------|----------|
+| Animals not detected | Lower detection threshold in `inference_cfg.yaml` |
+| ID swaps | Use `track_method="skeleton"` for more robust tracking |
+| Animals too similar | Add distinguishing features (ear tags, fur marks) or use re-identification |
+| Detection too slow | Use `fasterrcnn_mobilenet_v3_large_fpn` as detector |
+| Missing keypoints on occluded animals | Increase `numframes2pick`, add more labeled frames with occlusions |

--- a/skills/deeplabcut/references/modelzoo.md
+++ b/skills/deeplabcut/references/modelzoo.md
@@ -1,0 +1,98 @@
+# SuperAnimal & Model Zoo Reference
+
+## Table of Contents
+1. [SuperAnimal Overview](#superanimal-overview)
+2. [Zero-Shot Inference](#zero-shot-inference)
+3. [Fine-Tuning a SuperAnimal Model](#fine-tuning-a-superanimal-model)
+4. [Available Models](#available-models)
+
+## SuperAnimal Overview
+
+SuperAnimal models are pretrained across diverse datasets and can perform pose estimation on new animals without any additional training data. They support:
+- Top-view mice (various strains, fur colors)
+- Quadrupeds (dogs, horses, sheep, pigs, cheetahs, etc.)
+- Primate/human faces
+
+## Zero-Shot Inference
+
+Use `video_inference_superanimal` for out-of-the-box inference without any labeled data:
+
+```python
+import deeplabcut as dlc
+
+# Single video inference
+dlc.video_inference_superanimal(
+    videos=["/path/to/video.mp4"],
+    superanimal_name="superanimal_topviewmouse",
+    model_name="hrnet_w32",
+    detector_name="fasterrcnn_resnet50_fpn_v2",
+    scale_list=[200, 300, 400],
+    videotype=".mp4",
+)
+```
+
+**Key parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `videos` | List of video paths |
+| `superanimal_name` | Which pretrained model to use |
+| `model_name` | Pose model: `hrnet_w32`, `hrnet_w48` |
+| `detector_name` | Detector: `fasterrcnn_resnet50_fpn_v2` |
+| `scale_list` | Scales to try for detection; `[200, 300, 400]` is a good default. Larger animals → lower values (e.g. `[100, 200]`), smaller → higher (e.g. `[400, 600]`) |
+
+## Fine-Tuning a SuperAnimal Model
+
+When you have some labeled data, fine-tune for better accuracy:
+
+```python
+# Create a project from a SuperAnimal model
+config_path = dlc.create_pretrained_project(
+    path="my-superanimal-project",
+    task="my_task",
+    videos=["/path/to/video.mp4"],
+    superanimal_name="superanimal_topviewmouse",
+    model_name="hrnet_w32",
+    detector_name="fasterrcnn_resnet50_fpn_v2",
+    working_directory="/path/to/projects",
+    copy_videos=False,
+)
+
+# Now use the standard pipeline:
+# 1. extract_frames -> 2. label_frames -> 3. create_training_dataset -> 4. train_network
+# The pretrained weights give a huge head start; often 5K-20K iterations suffice.
+```
+
+## Available Models
+
+### Pose Models (`model_name`)
+
+| Model | Description |
+|-------|-------------|
+| `hrnet_w32` | Default, good balance of speed/accuracy |
+| `hrnet_w48` | Higher accuracy, more parameters |
+| `resnet_50` | ResNet-50 backbone |
+| `resnet_101` | ResNet-101 backbone |
+
+### Detectors (`detector_name`)
+
+| Detector | Description |
+|----------|-------------|
+| `fasterrcnn_resnet50_fpn_v2` | Default, good for multi-animal |
+| `fasterrcnn_mobilenet_v3_large_fpn` | Lighter, faster |
+
+### SuperAnimal Species
+
+| `superanimal_name` | Species | Keypoints |
+|---------------------|---------|-----------|
+| `superanimal_topviewmouse` | Top-view mice | 21 (nose, ears, limbs, tail base) |
+| `superanimal_quadruped` | Dogs, horses, sheep, pigs, etc. | 39 |
+| `superanimal_face` | Primate/human faces | 54 |
+| `superanimal_full` | Combined topview mouse + quadruped | Combined |
+
+## Tips
+
+- **Scale is critical**: If detections are poor, tune `scale_list`. Each value represents a different box size. Start with `[200, 300, 400]` and expand the range if needed.
+- **GPU required**: SuperAnimal models require a GPU for practical use.
+- **`create_pretrained_project` uses symbolic links**: the model weights are linked, not copied, so don't delete the original.
+- **dlclibrary**: Models are downloaded via `dlclibrary` from HuggingFace on first use.

--- a/skills/deeplabcut/references/standard-pipeline.md
+++ b/skills/deeplabcut/references/standard-pipeline.md
@@ -1,0 +1,165 @@
+# Standard Pipeline Reference
+
+## Table of Contents
+1. [Create a Project](#create-a-project)
+2. [Extract & Label Frames](#extract-label-frames)
+3. [Create Training Dataset](#create-training-dataset)
+4. [Train & Evaluate](#train-evaluate)
+5. [Analyze Videos](#analyze-videos)
+6. [Export Results](#export-results)
+
+## Create a Project
+
+```python
+import deeplabcut as dlc
+
+config_path = dlc.create_new_project(
+    "ProjectName",       # project name
+    "ExperimenterName",  # your name
+    ["/path/to/video.mp4"],      # video(s) to add
+    working_directory="/path/to/projects",
+    copy_videos=False,   # True = copy, False = symlink
+    multianimal=False,   # True for maDLC
+)
+```
+
+A `config.yaml` is created. Edit it to adjust bodyparts, skeleton, etc. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `bodyparts` | List of body part names to track |
+| `skeleton` | Pairs of bodyparts for skeleton lines in visualization |
+| `numframes2pick` | How many frames to extract for labeling (~20 recommended) |
+| `TrainingFraction` | Fraction of data used for training (e.g. `[0.95]`) |
+| `iteration` | Training iteration identifier |
+
+## Extract & Label Frames
+
+```python
+# Extract frames for manual labeling
+dlc.extract_frames(
+    config_path,
+    mode="automatic",    # or "manual"
+    algo="kmeans",       # clustering method: kmeans, uniform
+    crop=True,           # crop around animal for better labeling
+    userfeedback_percentage=20,
+)
+
+# User labels frames using the GUI
+# dlc.label_frames(config_path)  # opens labeling GUI
+
+# After labeling, check labels for completeness
+dlc.check_labels(config_path, display_suggestions=True)
+```
+
+**Labeling tips:**
+- Label ~20-50 frames for good initial results
+- Use `kmeans` algorithm for diverse frame selection
+- Set `crop=True` to zoom in on animals for precise labeling
+
+## Create Training Dataset
+
+```python
+dlc.create_training_dataset(
+    config_path,
+    net_type="resnet_50",     # see net types below
+    augmenter_type="imgaug",   # or "tensorpack", "default"
+    num_shuffles=1,
+)
+```
+
+Available architectures:
+
+| `net_type` | Best for |
+|-----------|----------|
+| `resnet_50` | Default, good accuracy-speed balance |
+| `resnet_101` | Higher accuracy, slower|
+| `resnet_152` | Maximum accuracy |
+| `mobilenet_v2_1.0` | Lightweight, faster inference |
+| `efficientnet-b0` | Efficient, good for deployment |
+| `dlcrnet_ms5` | Multi-scale, good for small body parts |
+
+## Train & Evaluate
+
+```python
+# Train
+dlc.train_network(
+    config_path,
+    maxiters=100000,     # more iters = more training
+    saveiters=5000,      # checkpoint interval
+    displayiters=500,    # console update interval
+    max_snapshots_to_keep=5,
+)
+
+# Evaluate on test set
+dlc.evaluate_network(
+    config_path,
+    Shuffles=[1],
+    plotting=True,
+    show_errors=True,
+)
+
+# Evaluate returns: train_error, test_error, p_cutoff
+# p_cutoff: probability threshold for good predictions
+```
+
+**Key metrics:**
+- RMSE < 5 pixels is usually "good enough"
+- Use `p_cutoff` from evaluation to filter predictions later
+- If accuracy is low: label more frames, use deeper network, increase `maxiters`
+
+## Analyze Videos
+
+```python
+# Predict poses for all frames
+dlc.analyze_videos(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    save_as_csv=True,
+    batchsize=8,
+)
+
+# Create labeled video with predictions overlaid
+dlc.create_labeled_video(
+    config_path,
+    ["/path/to/video.mp4"],
+    filtered=True,      # apply ARIMA filtering
+    trailpoints=10,     # trail length for visualization
+)
+
+# Filter predictions (removes jitter)
+dlc.filterpredictions(
+    config_path,
+    ["/path/to/video.mp4"],
+    filtertype="arima",   # or "median"
+    ARdegree=3,
+    MAdegree=1,
+)
+```
+
+## Export Results
+
+H5 files are in the video directory. Export to CSV:
+
+```python
+# Export to CSV
+dlc.analyze_videos_converth5_to_csv(
+    "/path/to/videoDLC_resnet50_ProjectNameJul9",
+    videotype=".mp4",
+)
+
+# Convert to NWB (Neurodata Without Borders)
+dlc.analyze_videos_converth5_to_nwb(
+    "/path/to/videoDLC_resnet50_ProjectNameJul9",
+    scorer="YourName",
+)
+
+# Plot trajectories
+dlc.plot_trajectories(
+    config_path,
+    ["/path/to/video.mp4"],
+    filtered=True,
+    showfigure=True,
+)
+```

--- a/skills/deeplabcut/references/utilities.md
+++ b/skills/deeplabcut/references/utilities.md
@@ -1,0 +1,146 @@
+# Video & Data Utilities Reference
+
+## Table of Contents
+1. [Video Preprocessing](#video-preprocessing)
+2. [Post-Processing Predictions](#post-processing-predictions)
+3. [Data Export & Conversion](#data-export-conversion)
+4. [Skeleton Analysis](#skeleton-analysis)
+5. [Outlier Detection](#outlier-detection)
+
+## Video Preprocessing
+
+```python
+import deeplabcut as dlc
+
+# Collect all videos in a directory
+videos = dlc.collect_video_paths("/path/to/video_dir", videotype=[".mp4", ".avi"])
+
+# Check video integrity
+dlc.check_video_integrity(videos)
+
+# Crop video
+dlc.CropVideo("/path/to/video.mp4", start=100, end=5000, output_path="cropped.mp4")
+
+# Downsample (reduce frame rate)
+dlc.DownSampleVideo("/path/to/video.mp4", factor=2, output_path="downsampled.mp4")
+
+# Shorten video
+dlc.ShortenVideo("/path/to/video.mp4", start="00:00:05", stop="00:05:00", output_path="short.mp4")
+```
+
+## Post-Processing Predictions
+
+```python
+# Filter jittery predictions
+dlc.filterpredictions(
+    config_path,
+    ["/path/to/video.mp4"],
+    filtertype="arima",    # or "median"
+    ARdegree=3,
+    MAdegree=1,
+    p_bound=0.5,           # min probability to keep
+)
+
+# Create video with all raw detections (before filtering)
+dlc.create_video_with_all_detections(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+)
+```
+
+**Filter tips:**
+- `arima`: Better for smooth tracking, uses temporal context
+- `median`: Simple, fast, good for quick cleanup
+- Low `p_bound` (0.1) keeps more predictions; high (0.9) is more conservative
+
+## Data Export & Conversion
+
+```python
+# Convert H5 to CSV
+dlc.analyze_videos_converth5_to_csv(
+    "/path/to/output_folder",
+    videotype=".mp4",
+    scorer="YourName",
+)
+
+# Convert CSV to H5
+dlc.convertcsv2h5("config.yaml", "user_specified")
+
+# Convert single-animal project to maDLC format
+dlc.convert2_maDLC(config_path, num_bodyparts=6)
+
+# Export to NWB (supports NWB 2.0)
+dlc.analyze_videos_converth5_to_nwb(
+    "/path/to/output_folder",
+    scorer="YourName",
+    videotype=".mp4",
+    individual_name="mouse1",
+)
+```
+
+## Skeleton Analysis
+
+Compute bone lengths and joint angles from predictions:
+
+```python
+dlc.analyzeskeleton(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    save_as_csv=True,
+    filtered=True,
+)
+```
+
+## Outlier Detection
+
+Find and relabel problematic frames:
+
+```python
+# Find outliers in raw predictions
+dlc.find_outliers_in_raw_data(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+)
+
+# Extract outlier frames for relabeling
+dlc.extract_outlier_frames(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    extractionalgorithm="jump",  # or "uncertain", "manual"
+    p_bound=0.5,
+)
+```
+
+**Extraction algorithms:**
+- `"jump"`: Find frames where body parts jump more than expected
+- `"uncertain"`: Find frames with low prediction confidence
+- `"manual"`: Use outlier data from `find_outliers_in_raw_data`
+
+## Merge Datasets
+
+Combine training data from multiple projects:
+
+```python
+# Merge two labeled datasets
+dlc.merge_datasets(
+    config_path,
+    [project_config1_path, project_config2_path],
+)
+```
+
+## Trajectory Plotting
+
+```python
+dlc.plot_trajectories(
+    config_path,
+    ["/path/to/video.mp4"],
+    videotype=".mp4",
+    filtered=True,
+    displayedbodyparts=["nose", "tailbase"],
+    showfigure=True,
+)
+```

--- a/skills/markdown-report-writing/SKILL.md
+++ b/skills/markdown-report-writing/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: markdown-report-writing
+description: Guide AI agents to write beautifully formatted, well-illustrated Markdown reports with proper structure, diagrams, and compatibility across GitHub and Obsidian. Use this skill whenever the user asks you to write a report, project documentation, experiment report, README, technical document, or any long-form Markdown content. Also trigger when users mention Markdown formatting, Mermaid diagrams, report templates, or document publishing.
+---
+
+# Markdown Report Writing
+
+Provide expert guidance for writing professional, visually polished Markdown reports that render correctly on both GitHub and Obsidian.
+
+## Core Philosophy: Three-Layer Writing Model
+
+When writing any Markdown report, think in three layers:
+
+1. **Content layer** — Use CommonMark / GFM + Obsidian shared syntax for all headings, paragraphs, lists, images, tables, code blocks, footnotes, task lists, math ($\LaTeX$), and Mermaid diagrams. This is your foundation.
+2. **Enhancement layer** — Add renderer-specific features only when necessary: GitHub `<details>` folding, relative links; Obsidian `[[wikilink]]`, `![[embed]]`, Callout, `cssclasses`.
+3. **Build layer** — For complex layouts, table of contents generation, site styling, and slide exports, delegate to Pandoc / Quarto / MkDocs / GitHub Pages.
+
+This ensures your output is readable, portable, automatable, and version-controllable across all target environments.
+
+## Writing Principles
+
+Follow these rules for every report:
+
+1. **Shared syntax first** — Build the body with syntax that works on both GitHub and Obsidian (headings, links, images, tables, code blocks, footnotes, task lists, Mermaid, math).
+2. **Relative paths for all assets** — Place images, diagrams, and attachments in `assets/` and reference them with relative paths.
+3. **Enhance per target** — After the core is solid, add renderer-specific enhancements:
+   - **GitHub**: relative links, section anchors, `<details>`, Mermaid
+   - **Obsidian**: wikilink, embed, callout, cssclasses
+   - **Web/PDF/Slides**: delegate to Pandoc / Quarto / MkDocs
+4. **Don't nest Markdown in HTML** — GitHub strips custom HTML attributes; Obsidian won't parse Markdown inside HTML blocks. Use Markdown tables for side-by-side layouts instead of `<div>` flexboxes.
+5. **Mermaid first for diagrams** — GitHub and Obsidian both render Mermaid natively. For complex UML, generate PlantUML SVG first, then embed.
+6. **Every figure needs alt text and a caption** — Every code block must declare its language.
+7. **Every long document must have**: executive summary, table of contents (or equivalent navigation), figures with captions, and a conclusion / next-steps section.
+
+## Quality Checklist
+
+After generating any report, verify:
+
+- [ ] All code blocks have language identifiers
+- [ ] All images have alt text and captions
+- [ ] All links use relative paths (no absolute paths to local files)
+- [ ] Table of contents is present (for documents with 3+ sections)
+- [ ] Mermaid diagrams render correctly
+- [ ] Footnotes are properly paired (marker + definition)
+- [ ] No complex Markdown trapped inside HTML blocks
+
+## Standard Document Skeleton
+
+Start every report with this upgradeable structure:
+
+```md
+---
+title: Project Name
+author: Team / Agent Name
+date: YYYY-MM-DD
+tags: [tag1, tag2]
+---
+
+# Project Name
+
+> One-line summary: what problem this solves and what the conclusion is.
+
+## Executive Summary
+
+3-6 sentences covering background, approach, results, and conclusions.
+
+## Background
+
+Problem statement, context, and boundaries.
+
+## Methods / Approach
+
+Solution design, workflow, data, experimental conditions.
+
+## Results
+
+- Key finding A
+- Key finding B
+- Key finding C
+
+## Conclusion / Next Steps
+
+## Appendix & References
+
+- [Raw data](./data/raw.csv)
+- [Diagrams](./assets/fig-overview.svg)
+- [Supplementary docs](./docs/appendix.md)
+```
+
+## Layout & Typesetting Techniques
+
+### Images and Figures
+
+Always provide alt text. Use SVG for diagrams, PNG/WebP for screenshots:
+
+```md
+![System architecture diagram](./assets/fig-system-architecture.svg)
+*Figure: Overall system architecture.*
+
+[View full-size SVG](./assets/fig-system-architecture.svg)
+```
+
+### Side-by-Side Layout (Cross-Platform Safe)
+
+Use **two-column Markdown tables** as your grid system — this is the only approach that works reliably on both GitHub and Obsidian:
+
+```md
+| Overview | Key Points |
+|---|---|
+| ![System overview](./assets/fig-overview.svg) | - 4 modules<br>- 12 interfaces<br>- Risk: data sync |
+```
+
+Avoid `<div style="display:flex">` — styles get stripped on GitHub and block Markdown parsing on Obsidian.
+
+### Tables
+
+Always use standard Markdown tables. Escape `|` inside cells with `\|`:
+
+```md
+| Metric | Value | Notes |
+|:--|--:|:--|
+| Accuracy | 92.4% | Main model |
+| Link to doc | [Appendix](./docs/appendix.md) | See details |
+```
+
+### Code Blocks
+
+Always declare the language for syntax highlighting:
+
+```md
+​```python
+def evaluate(x: float) -> float:
+    return x ** 2 + 1
+​```
+```
+
+### Mermaid Diagrams
+
+Use fenced code blocks — both GitHub and Obsidian render them natively:
+
+```md
+​```mermaid
+flowchart LR
+    Data[Data Input] --> Clean[Cleaning]
+    Clean --> Analyze[Analysis]
+    Analyze --> Report[Report Output]
+​```
+```
+
+### Math Expressions
+
+Both GitHub and Obsidian support $\LaTeX$ via MathJax:
+
+```md
+Inline: $E = mc^2$
+
+Block:
+$$
+\operatorname{F1} = \frac{2PR}{P+R}
+$$
+```
+
+### Task Lists and Collapsible Sections
+
+```md
+- [x] Requirements confirmed
+- [x] Data collected
+- [ ] Charts reviewed
+- [ ] Document published
+
+<details>
+<summary>Click to expand technical details</summary>
+
+Keep content here plain text or simple HTML.
+Avoid complex Markdown (lists, tables, formulas) inside
+if the target includes Obsidian.
+
+</details>
+```
+
+### Footnotes
+
+Use for citations, terminology, and data sources:
+
+```md
+There is a term that needs explanation[^term].
+
+[^term]: This is where the explanation or citation goes.
+```
+
+## Report Templates
+
+### 1. Project Report
+
+Use when reporting project status, milestones, architecture decisions, risks, and next steps.
+
+Required sections: Executive Summary → Background → Scope → Architecture & Design → Current Progress → Risks & Mitigation → Conclusion & Next Steps → Appendix.
+
+Include: a system architecture diagram (Mermaid), a progress table with status per task, a risk matrix table, and a task checklist for next steps.
+
+### 2. Experiment Report
+
+Use when documenting experiments, A/B tests, benchmarks, or research findings.
+
+Required sections: Executive Summary → Research Questions & Hypotheses → Experimental Setup → Variables → Procedure → Results → Discussion → Reproducibility → Conclusion.
+
+Include: an environment/config table, a variables table (independent, dependent, controlled), a results comparison table, a results chart, and links to scripts/configs/raw data for reproducibility.
+
+### 3. README
+
+Use for repository introductions and project documentation.
+
+Required sections: Project Name & tagline → Quick-start links → Description → Features → Project Structure → Quick Start (install, run, example) → Usage (with Mermaid flow) → Documentation links → Roadmap → Contributing → License.
+
+See `references/templates.md` for full expanded templates with annotations.
+
+## Choosing Tools for the Job
+
+| Goal | Primary Tool | Agent Should Output |
+|---|---|---|
+| Repo README / project report | Pure GFM + Mermaid | `.md` + `assets/*.svg` |
+| Experiment report / PDF export | Quarto | `.qmd` or enhanced `.md` → export HTML/PDF |
+| Documentation site | MkDocs Material | `docs/` directory + nav config |
+| Diagrams | Mermaid (first), PlantUML (UML) | `*.mmd` / `*.puml` source + rendered `*.svg` |
+| Math rendering on web | MathJax | HTML site with math rendering layer |
+| Local editing & export | Typora | Preview → export HTML/PDF |
+| Slides / presentation | Quarto Revealjs or Pandoc | `.qmd` or `.md` → rendered slides |
+
+### Rendering Commands
+
+```bash
+# Mermaid → SVG
+mmdc -i diagrams/flow.mmd -o assets/flow.svg
+
+# PlantUML → SVG
+java -jar plantuml.jar --svg diagrams/architecture.puml
+
+# Pandoc → HTML / PDF / Revealjs
+pandoc report.md -o report.html
+pandoc report.md -o report.pdf
+pandoc -t revealjs -s slides.md -o slides.html
+
+# Quarto → HTML / Website / Revealjs
+quarto render report.qmd --to html
+quarto render report.qmd --to pdf
+quarto render slides.qmd --to revealjs
+```
+
+## File & Asset Management
+
+Organize project files with this directory structure:
+
+```text
+project/
+├── README.md
+├── reports/
+│   ├── project-report.md
+│   └── experiment-report.md
+├── docs/
+│   ├── index.md
+│   └── appendix.md
+├── assets/
+│   ├── figures/
+│   │   ├── fig-system-architecture.svg
+│   │   └── fig-results-comparison.svg
+│   ├── screenshots/
+│   │   └── screenshot-dashboard-home.png
+│   └── generated/
+│       ├── flow-overview.svg
+│       └── gantt-plan.svg
+├── diagrams/
+│   ├── flow-overview.mmd
+│   └── architecture.puml
+├── data/
+│   ├── raw/
+│   └── processed/
+└── .github/workflows/
+    └── docs-check.yml
+```
+
+**Naming conventions**: lowercase, hyphen-separated, semantic prefixes (`fig-` for figures, `tbl-` for tables, `exp-` for experiment data, `shot-` for screenshots, `flow-` for flowcharts). Keep both **source files** (`*.mmd`, `*.puml`) and **derived files** (`*.svg`) for version control and CI regeneration.
+
+## CI Quality Pipeline
+
+Include these 4 checks for long-lived documentation:
+
+1. **Lint Markdown** — `markdownlint-cli2 "**/*.md"`
+2. **Check TOC freshness** — `doctoc --dryrun .`
+3. **Check links** — `lychee --verbose --no-progress "**/*.md"`
+4. **Render diagrams** — `mmdc -i diagrams/*.mmd -o assets/generated/`
+
+## Quick Reference: Per-Environment Differences
+
+| Situation | GitHub Approach | Obsidian Approach |
+|---|---|---|
+| Internal links | Relative paths (auto-branch-aware) | `[[wikilink]]` or Markdown links |
+| Embedding content | Standard `![alt](path)` | `![[file.svg\|700]]` |
+| Collapsible sections | `<details><summary>` (safe) | Heading folding or Callout |
+| Custom styling | Not available in repo `.md` | CSS Snippets + `cssclasses` frontmatter |
+| Slides | Not native | `---` separated slides in note |
+| Dynamic views | Not in repo `.md` | Dataview plugin queries |
+
+## References
+
+- `references/templates.md` — Full annotated templates for project reports, experiment reports, and README files
+- `references/compatibility-matrix.md` — Detailed compatibility table for GitHub vs Obsidian features

--- a/skills/markdown-report-writing/references/compatibility-matrix.md
+++ b/skills/markdown-report-writing/references/compatibility-matrix.md
@@ -1,0 +1,72 @@
+# GitHub Markdown vs Obsidian Compatibility Matrix
+
+This reference covers which features work on each platform and the recommended approach for cross-platform documents.
+
+## Quick Decision Table
+
+| Feature | GitHub | Obsidian | Cross-Platform Recommendation |
+|---|---|---|---|
+| Headings, lists, quotes, code blocks | Full | Full | Always use; the minimum shared subset |
+| Internal links | Relative paths (branch-aware) | `[[wikilink]]`, Markdown links, heading/block refs | Use Markdown relative links for cross-platform; `[[wikilink]]` only for Obsidian-only notes |
+| Images & SVG | PNG/JPG/GIF/SVG supported; SVG no scripts/animations | `.svg` + image embed supported | Diagrams → SVG; screenshots → PNG/WebP |
+| Footnotes | Full | Full | Use for citations, terminology, data sources |
+| Task lists | Clickable checkboxes | Native task lists | Use for TODOs, checklists, release checklists |
+| Tables | Full | Full (escape `\|` in cells) | Use standard Markdown tables; no complex cell styling |
+| Mermaid diagrams | Native rendering | Native support | Primary diagram language for agents; use fenced code blocks |
+| Math ($\LaTeX$) | MathJax-based | MathJax-based | Safe to use both inline and block formulas |
+| Collapsible content | `<details><summary>` works | HTML supported but Markdown won't parse inside HTML | GitHub: use `<details>`; Obsidian: use heading folding or Callout |
+| Raw HTML | Supported but aggressively sanitized (no `script`, inline `style`, `class`, `id`) | Supported but sanitized; Markdown not parsed inside HTML | Only for minimal structural patches; never for complex layouts |
+| Custom CSS | Not available in repo `.md` pages | CSS Snippets + `cssclasses` frontmatter | GitHub = content source; Obsidian/HTML site = style layer |
+| Slides/presentation | Not native in repo `.md` | Obsidian Slides (`---` page separators) | Export via Quarto Revealjs, Pandoc, or Obsidian Slides |
+| Dynamic views | Not in repo `.md` | Dataview plugin queries | Obsidian vault enhancement only |
+
+## Key Compatibility Rules
+
+### 1. HTML Sanitization
+
+**GitHub** strips: `script`, inline `style`, `class`, `id`, and other potentially abusable attributes from HTML in Markdown.
+
+**Obsidian** sanitizes HTML AND does not continue parsing Markdown inside HTML elements.
+
+**Result**: Never put complex Markdown (lists, tables, code blocks, math) inside HTML containers. Use native Markdown constructs instead.
+
+### 2. Side-by-Side Layout
+
+**Do NOT use**:
+```html
+<div style="display:flex">
+  <div>![img](a.svg)</div>
+  <div>Some text</div>
+</div>
+```
+
+**Use instead** (cross-platform safe):
+```md
+| Diagram | Description |
+|---|---|
+| ![img](./assets/a.svg) | - Point 1<br>- Point 2 |
+```
+
+### 3. Collapsible Sections
+
+**GitHub**: `<details><summary>Title</summary>...content...</details>` works well.
+
+**Obsidian**: HTML is supported but Markdown inside won't parse. Use Callout blocks or heading-based folding instead.
+
+**Cross-platform**: If you must use `<details>`, keep the content as plain text or simple HTML. Avoid nesting Markdown lists, tables, or code blocks inside.
+
+### 4. Links Strategy
+
+- Cross-platform text: Use **Markdown relative links** `[text](./path/file.md)`
+- Obsidian-only: Use `[[wikilink]]` and `![[embed]]`
+- GitHub: Relative links auto-adapt to the current branch
+
+### 5. Styling Strategy
+
+- GitHub repo `.md`: cannot inject custom CSS
+- Obsidian: use CSS Snippets (`.obsidian/snippets/`) + `cssclasses` frontmatter
+- Exported HTML/sites: add CSS at the site level (Pandoc, Quarto, MkDocs)
+
+## Bottom Line
+
+When in doubt, use **pure CommonMark/GFM syntax** (headings, links, images, tables, code blocks, footnotes, task lists, Mermaid, math). It renders correctly on both platforms and migrates cleanly to any export format.

--- a/skills/markdown-report-writing/references/templates.md
+++ b/skills/markdown-report-writing/references/templates.md
@@ -1,0 +1,299 @@
+# Markdown Report Templates (Annotated)
+
+## 1. Project Report Template
+
+```md
+---
+title: Project Name
+author: Team / Agent
+date: YYYY-MM-DD
+tags: [project, report]
+---
+
+# Project Name
+
+> One-line summary: this report covers project background, current progress, key risks, and next steps.
+
+## Executive Summary
+
+- Background:
+- Current phase:
+- Completed:
+- Key risks:
+- Next steps:
+
+## Project Background
+
+### Business Context
+
+### Problem Definition
+
+### Success Criteria
+
+## Project Scope
+
+### In Scope
+
+- [x] Feature A
+- [x] Feature B
+- [ ] Feature C
+
+### Out of Scope
+
+- Item 1
+- Item 2
+
+## Architecture & Design
+
+![System architecture diagram](./assets/fig-system.svg)
+
+*Figure: Overall system architecture.*
+
+### Core Modules
+
+| Module | Responsibility | Input | Output |
+|---|---|---|---|
+| Data Layer | Data ingestion | Raw data | Standardized data |
+| Service Layer | Analysis pipeline | Standardized data | Intermediate results |
+| Presentation Layer | Output rendering | Intermediate results | Reports & charts |
+
+### Key Workflow
+
+​```mermaid
+flowchart LR
+    A[Requirements] --> B[Design]
+    B --> C[Implementation]
+    C --> D[Testing]
+    D --> E[Delivery & Review]
+​```
+
+## Current Progress
+
+| Item | Owner | Status | Notes |
+|---|---|---|---|
+| Requirements confirmed | @owner | Complete | Frozen |
+| Data integration | @owner | In Progress | Awaiting API |
+| Report template | @owner | Complete | Mermaid + footnotes |
+| Release prep | @owner | Not Started | Depends on sign-off |
+
+## Risks & Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---|---|
+| Data inconsistency | High | Medium | Field mapping checks |
+| Broken asset links | Medium | Medium | Relative paths + CI validation |
+| Scope creep | Medium | High | Change freeze window |
+
+## Conclusion & Next Steps
+
+### Conclusion
+
+### Next Actions
+
+- [ ] Complete integration
+- [ ] Update diagrams
+- [ ] Validate links
+- [ ] Publish v1 report
+
+## Appendix
+
+- [Detailed design doc](./docs/design.md)
+- [Data dictionary](./docs/data-dictionary.md)
+- [System architecture SVG](./assets/fig-system.svg)
+
+## Footnotes
+
+Example terminology[^scope].
+
+[^scope]: Scope freeze means no new high-impact requirements are introduced past the agreed cutoff date.
+```
+
+---
+
+## 2. Experiment Report Template
+
+```md
+---
+title: Experiment Name
+author: Researcher / Agent
+date: YYYY-MM-DD
+tags: [experiment, report]
+---
+
+# Experiment Name
+
+> One-line summary: what was tested, with what method, and what was found.
+
+## Executive Summary
+
+- Hypothesis:
+- Method:
+- Key results:
+- Conclusion:
+
+## Research Questions & Hypotheses
+
+### Research Question
+
+### Hypothesis
+
+## Experimental Setup
+
+### Environment
+
+| Item | Value |
+|---|---|
+| OS | |
+| Software version | |
+| Dataset | |
+| Time range | |
+
+### Variables
+
+| Type | Variable | Description |
+|---|---|---|
+| Independent | | |
+| Dependent | | |
+| Controlled | | |
+
+## Procedure
+
+1. Data preparation
+2. Parameter configuration
+3. Experiment execution
+4. Result recording
+5. Statistical analysis
+
+​```mermaid
+flowchart TD
+    A[Data Prep] --> B[Execution]
+    B --> C[Recording]
+    C --> D[Analysis]
+    D --> E[Conclusion]
+​```
+
+## Results
+
+### Results Table
+
+| Method | Metric A | Metric B | Notes |
+|---|---:|---:|---|
+| Baseline | | | |
+| Method-1 | | | |
+| Method-2 | | | |
+
+### Charts
+
+![Results comparison chart](./assets/fig-results.svg)
+
+*Figure: Results comparison across methods.*
+
+## Discussion
+
+### Interpretation
+
+### Error Sources
+
+### Limitations
+
+## Reproducibility
+
+- [Experiment script](./code/run.py)
+- [Config file](./configs/exp.yaml)
+- [Raw results](./results/raw.csv)
+
+## Conclusion
+
+## Footnotes
+
+Terminology[^metric].
+
+[^metric]: Metric A is the primary evaluation metric; higher is better.
+```
+
+---
+
+## 3. README Template
+
+```md
+# Project Name
+
+> One-line description of the problem this solves and its core value.
+
+[Quick Start](#quick-start) · [Docs](./docs/index.md) · [Changelog](./CHANGELOG.md) · [License](./LICENSE)
+
+## About
+
+What this project is, who it's for, and how it differs from alternatives.
+
+## Features
+
+- Feature A
+- Feature B
+- Feature C
+
+## Project Structure
+
+| Path | Description |
+|---|---|
+| `src/` | Core source code |
+| `docs/` | Detailed documentation |
+| `assets/` | Images and diagrams |
+| `examples/` | Example inputs and outputs |
+
+## Quick Start
+
+### Installation
+
+​```bash
+# install command
+​```
+
+### Usage
+
+​```bash
+# run command
+​```
+
+### Example
+
+​```bash
+# example command
+​```
+
+## How It Works
+
+​```mermaid
+flowchart LR
+    A[Install] --> B[Configure]
+    B --> C[Run]
+    C --> D[View Results]
+​```
+
+### Input & Output
+
+| Type | Path | Description |
+|---|---|---|
+| Input | `examples/input.json` | Sample input |
+| Output | `examples/output.md` | Sample output |
+
+## Documentation
+
+- [User Guide](./docs/user-guide.md)
+- [Developer Guide](./docs/developer-guide.md)
+- [FAQ](./docs/faq.md)
+
+## Roadmap
+
+- [ ] Release v1.0
+- [ ] Plugin system
+- [ ] Documentation site
+
+## Contributing
+
+Issues and pull requests welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) first.
+
+## License
+
+This project is licensed under [MIT License](./LICENSE).
+```


### PR DESCRIPTION
## 目标

将 BrainPilot 内置 skills 库中已在生产使用的两个 skill 反向同步到 awesome_cognitive_and_neuroscience_skills：**deeplabcut**（动物行为跟踪）与 **markdown-report-writing**（Markdown 报告写作），并把 README 的计数与目录同步到磁盘真实状态。

## 新增 Skills（两个）

### 1. \`deeplabcut\` — Animal Behavior 新分类

Markerless animal pose estimation with DeepLabCut，覆盖：
- 单/多动物跟踪
- SuperAnimal 预训练模型
- 2D/3D 姿态估计
- 关键点标注 GUI
- 模型训练 / 评估
- 视频分析 + 行为量化

**Reference 文件（5）**：\`standard-pipeline.md\` · \`maDLC.md\` · \`3d-pose.md\` · \`modelzoo.md\` · \`utilities.md\`

上游：https://github.com/DeepLabCut/DeepLabCut

### 2. \`markdown-report-writing\` — Writing 新分类

Guide for well-structured Markdown reports that render correctly on both GitHub and Obsidian，覆盖：
- Three-layer writing model（content / enhancement / metadata）
- Mermaid 图表
- 数学公式、表格、callouts
- 跨渲染器兼容矩阵
- 报告模板

**Reference 文件（2）**：\`compatibility-matrix.md\` · \`templates.md\`

## README 同步

带着此 PR 顺手校准所有过时计数（当前 README 说 46 skills，磁盘上其实已经有 spikeinterface-skill / pycortex-guide / netneurotools-guide 等未列出的项目）。

**Badge / hero / catalog header**（三处一致改）
- \`skills-46-blue\` → \`skills-50-blue\`
- \`All 47 skills become immediately available\` → \`All 50 skills\`
- \`**46 skills** across 13 categories\` → \`**50 skills** across 16 categories\`

**新增分类章节**（本 PR）
- \`### Animal Behavior (1)\` — deeplabcut
- \`### Writing (1)\` — markdown-report-writing

**补齐先前 PR 未同步的章节**
- \`### Electrophysiology (1)\` — spikeinterface-skill（PR #11 已合并但 README 未列出）
- \`### fMRI / Neuroimaging (7)\` → \`(8)\`（pycortex-guide + netneurotools-guide 都合并了但计数没改）

## 验证

用脚本对齐 README 与磁盘：
\`\`\`
Categories in README: 16
Unique skill folders referenced: 50
Disk folder count: 50
On disk but NOT in README: (none)
In README but NOT on disk: (none)
Badge: 50 · Hero line: 50 · Catalog: 50 skills across 16 categories
\`\`\`

*注*：per-category 数字之和 = 52 而非 50，是因为 \`neural-decoding-analysis\` 和 \`brain-connectivity-modeler\` 分别在 fMRI/Neuroimaging 和 Computational Neuroscience 两处列出（README 既有惯例，方便跨领域读者定位）。

## 显式非目标

- 不改任何已合入 skill 的内容 —— 只增加 README 里的引用
- 不改 CONTRIBUTING/CODE_OF_CONDUCT/plugin manifest 等元文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)